### PR TITLE
Make `client` object handle all communication.

### DIFF
--- a/smartrent/device.py
+++ b/smartrent/device.py
@@ -2,7 +2,7 @@ import json
 import asyncio
 import inspect
 
-from typing import Union
+from typing import Union, List, Dict
 import logging
 
 import websockets
@@ -38,7 +38,7 @@ class Device:
         self.stop_updater()
 
     @staticmethod
-    def _structure_attrs(attrs: list):
+    def _structure_attrs(attrs: List[Dict[str, any]]) -> Dict[str, any]:
         """
         Converts device json object to hirearchical list of attributes
 
@@ -55,7 +55,7 @@ class Device:
         _LOGGER.info("constructed attribute structure: %s", structure)
         return structure
 
-    def _fetch_state_helper(self, data: dict):
+    def _fetch_state_helper(self, data: Dict[str, str]):
         """
         Called by ``_async_fetch_state``
 
@@ -110,7 +110,7 @@ class Device:
         """
         self._update_callback_func = func
 
-    def _update_parser(self, event: dict) -> None:
+    def _update_parser(self, event: Dict[str, any]) -> None:
         """
         Called by ``_async_update_state``
 

--- a/smartrent/device.py
+++ b/smartrent/device.py
@@ -65,11 +65,7 @@ class Device:
             if device["id"] == self._device_id:
                 self._fetch_state_helper(device)
 
-                for func in self._update_callback_funcs:
-                    if inspect.iscoroutinefunction(func):
-                        await func()
-                    else:
-                        func()
+                await self._async_call_callbacks()
 
     def start_updater(self):
         """
@@ -110,11 +106,21 @@ class Device:
         """
         raise NotImplementedError
 
-    async def _update(self, event):
+    async def _update(self, event: Dict[str, any]):
+        """
+        Recieves event dict, calls ``_update_parser`` for each device and callbacks
+        """
+
         # handle updating of device attrs
         self._update_parser(event)
 
         # handle calling callbacks
+        await self._async_call_callbacks()
+
+    async def _async_call_callbacks(self):
+        """
+        Handles calling all callbacks
+        """
         for func in self._update_callback_funcs:
             if inspect.iscoroutinefunction(func):
                 await func()

--- a/smartrent/device.py
+++ b/smartrent/device.py
@@ -120,6 +120,3 @@ class Device:
                 await func()
             else:
                 func()
-
-    async def _async_send_command(self, attribute_name: str, value: str):
-        await self._client._async_send_command(self, attribute_name, value)

--- a/smartrent/lock.py
+++ b/smartrent/lock.py
@@ -39,7 +39,9 @@ class DoorLock(Device):
         # Convert to lowercase just like SmartRent website does
         value = str(value).lower()
 
-        await self._async_send_command(attribute_name="locked", value=value)
+        await self._client._async_send_command(
+            self, attribute_name="locked", value=value
+        )
 
     def _fetch_state_helper(self, data: dict):
         """

--- a/smartrent/switch.py
+++ b/smartrent/switch.py
@@ -31,7 +31,7 @@ class BinarySwitch(Device):
         # Convert to lowercase just like SmartRent website does
         value = str(value).lower()
 
-        await self._async_send_command(attribute_name="on", value=value)
+        await self._client._async_send_command(self, attribute_name="on", value=value)
 
     def _fetch_state_helper(self, data: dict):
         """

--- a/smartrent/thermostat.py
+++ b/smartrent/thermostat.py
@@ -63,7 +63,9 @@ class Thermostat(Device):
 
         ``value`` str or int representing temperature to set
         """
-        await self._async_send_command(attribute_name="heating_setpoint", value=value)
+        await self._client._async_send_command(
+            self, attribute_name="heating_setpoint", value=value
+        )
 
         self._heating_setpoint = int(value)
 
@@ -73,7 +75,9 @@ class Thermostat(Device):
 
         ``value`` str or int representing temperature to set
         """
-        await self._async_send_command(attribute_name="cooling_setpoint", value=value)
+        await self._client._async_send_command(
+            self, attribute_name="cooling_setpoint", value=value
+        )
 
         self._cooling_setpoint = int(value)
 
@@ -86,7 +90,7 @@ class Thermostat(Device):
         if mode not in ["aux_heat", "heat", "cool", "auto", "off"]:
             return
 
-        await self._async_send_command(attribute_name="mode", value=mode)
+        await self._client._async_send_command(self, attribute_name="mode", value=mode)
 
         self._mode = mode
 
@@ -99,7 +103,8 @@ class Thermostat(Device):
         if fan_mode not in ["on", "auto"]:
             return
 
-        await self._async_send_command(
+        await self._client._async_send_command(
+            self,
             attribute_name="fan_mode",
             value=fan_mode,
         )

--- a/smartrent/utils.py
+++ b/smartrent/utils.py
@@ -1,8 +1,14 @@
 import asyncio
 import logging
-from typing import List
+import json
+import traceback
+from typing import List, Set, TYPE_CHECKING, Union
 
 import aiohttp
+import websockets
+
+if TYPE_CHECKING:
+    from smartrent.device import Device
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -11,6 +17,16 @@ SMARTRENT_SESSIONS_URI = SMARTRENT_BASE_URI + "sessions"
 SMARTRENT_TOKENS_URI = SMARTRENT_BASE_URI + "tokens"
 SMARTRENT_HUBS_URI = SMARTRENT_BASE_URI + "hubs"
 SMARTRENT_HUBS_ID_URI = SMARTRENT_BASE_URI + "hubs/{}/devices"
+
+SMARTRENT_WEBSOCKET_URI = (
+    "wss://control.smartrent.com/socket/websocket?token={}&vsn=2.0.0"
+)
+JOINER_PAYLOAD = '["null", "null", "devices:{device_id}", "phx_join", {{}}]'
+COMMAND_PAYLOAD = (
+    '["null", "null", "devices:{device_id}", "update_attributes", '
+    '{{"device_id": {device_id}, '
+    '"attributes": [{{"name": "{attribute_name}", "value": "{value}"}}]}}]'
+)
 
 
 class SmartRentError(Exception):
@@ -38,7 +54,10 @@ class Client:
     """
 
     def __init__(
-        self, email: str, password: str, aiohttp_session: aiohttp.ClientSession = None
+        self,
+        email: str,
+        password: str,
+        aiohttp_session: aiohttp.ClientSession = None,
     ):
         self._email = email
         self._password = password
@@ -50,6 +69,10 @@ class Client:
         self._token = None
         self._refresh_token = None
         self._token_exp_time = None
+
+        self._subscribed_devices: Set["Device"] = set()
+        self._updater_task = None
+        self._ws = None
 
     def __del__(self):
         """
@@ -69,6 +92,11 @@ class Client:
                 _LOGGER.debug("Making new event loop")
                 new_loop = asyncio.new_event_loop()
                 new_loop.run_until_complete(self._aiohttp_session.close())
+
+        if self._updater_task:
+            _LOGGER.info("Stopping updater task")
+            self._updater_task.cancel()
+            self._ws = None
 
     async def async_get_devices_data(self) -> List[dict]:
         """
@@ -169,3 +197,187 @@ class Client:
         headers = {"authorization-x-refresh": self._refresh_token}
         resp = await self._aiohttp_session.post(SMARTRENT_TOKENS_URI, headers=headers)
         return await resp.json()
+
+    def _subscribe_device_to_updater(self, device: "Device"):
+        """
+        Subscribes device to recieve updates
+        """
+        self._subscribed_devices.add(device)
+
+        if not self._updater_task:
+            _LOGGER.info("Starting updater task")
+            self._updater_task = asyncio.create_task(self._async_update_state())
+
+        elif self._updater_task:
+            if self._updater_task.cancelled():
+                _LOGGER.info(
+                    "Updater task was previously canceled. Starting updater task again."
+                )
+                self._updater_task = asyncio.create_task(self._async_update_state())
+
+        if self._ws:
+            joiner = JOINER_PAYLOAD.format(device_id=device._device_id)
+            _LOGGER.info(
+                "%s: Joining topic for %s:%s ...",
+                device._name,
+                device._name,
+                device._device_id,
+            )
+            asyncio.create_task(self._ws.send(joiner))
+
+    def _unsubscribe_device_to_updater(self, device: "Device"):
+        try:
+            self._subscribed_devices.remove(device)
+        except KeyError:
+            pass
+
+        if self._updater_task:
+            if (
+                not self._updater_task.cancelled()
+                and len(self._subscribed_devices) == 0
+            ):
+                _LOGGER.info("Device list empty. Stopping updater task for now.")
+                self._updater_task.cancel()
+                self._ws = None
+
+    async def _async_update_state(self):
+        """
+        Connects to SmartRent websocket and listens for updates.
+        To be ran in the background. You can call ``start_updater`` and ``stop_updater``
+        to turn ``_async_update_state`` on or off.
+
+        Calls ``_update_parser`` method for device when event is found
+        """
+
+        retries = 0
+        while True:
+            try:
+                self._ws = None
+
+                _LOGGER.info("Getting new token")
+                await self.async_refresh_token()
+                token = self.get_current_token()
+
+                _LOGGER.info("Fetching current status for all devices...")
+                await asyncio.gather(
+                    *[
+                        device._async_fetch_state()
+                        for device in self._subscribed_devices
+                    ]
+                )
+                _LOGGER.info("Done fetching data!")
+
+                uri = SMARTRENT_WEBSOCKET_URI.format(token)
+
+                _LOGGER.info("Connecting to Websocket...")
+                async with websockets.connect(uri) as websocket:
+
+                    # if we connect sucessfully at least one time, reset retries to 0
+                    retries = 0
+
+                    self._ws = websocket
+
+                    for device in self._subscribed_devices:
+                        joiner = JOINER_PAYLOAD.format(device_id=device._device_id)
+                        _LOGGER.info(
+                            "%s: Joining topic for %s:%s ...",
+                            device._name,
+                            device._name,
+                            device._device_id,
+                        )
+                        await websocket.send(joiner)
+
+                    while True:
+                        resp = await websocket.recv()
+
+                        formatted_resp = json.loads(f"{resp}")[4]
+                        device_id = json.loads(f"{resp}")[2].split(":")[-1]
+
+                        event_type = formatted_resp.get("type", "")
+                        event_name = formatted_resp.get("name", "")
+                        event_last_read_state = formatted_resp.get(
+                            "last_read_state", ""
+                        )
+
+                        if event_type:
+                            event = (
+                                f"{event_type:<15} -> "
+                                f"{event_name:<15} -> "
+                                f"{event_last_read_state:<20}"
+                            )
+                            _LOGGER.info(str(event))
+
+                            for d in self._subscribed_devices:
+                                if d._device_id == int(device_id):
+                                    await d._update(formatted_resp)
+                        else:
+                            _LOGGER.info(str(resp))
+
+            except Exception as exc:
+                _LOGGER.warning(
+                    "Exception occured! %s %s", type(exc).__name__, type(exc)
+                )
+                _LOGGER.warning(traceback.format_exc())
+
+                # set websocket to None
+                self._ws = None
+
+                wait_time = 1.25 ** retries
+                wait_time = wait_time if wait_time < 300 else 300
+                _LOGGER.warning("Got excpetion: %s", exc)
+                _LOGGER.warning("Retrying websocket in %s seconds...", wait_time)
+
+                await asyncio.sleep(wait_time)
+
+                retries += 1
+
+    async def _async_send_command(
+        self, device: "Device", attribute_name: str, value: str
+    ):
+        """
+        Sends command to SmartRent websocket
+
+        ``attribute_name`` string of attribute to change
+        ``value`` value for that attribute to be changed to
+        """
+        payload = COMMAND_PAYLOAD.format(
+            attribute_name=attribute_name, value=value, device_id=device._device_id
+        )
+
+        await self._async_send_payload(device._device_id, payload)
+
+    async def _async_send_payload(self, device_id: Union[str, int], payload: str):
+        """
+        Sends payload to SmartRent websocket
+
+        ``payload`` string of device attributes
+        """
+        _LOGGER.info("sending payload %s", payload)
+
+        async def sender(uri: str, payload: str):
+            async with websockets.connect(uri) as websocket:
+                joiner = JOINER_PAYLOAD.format(device_id=device_id)
+
+                # Join topic given device id
+                await websocket.send(joiner)
+                # Send payload
+                await websocket.send(payload)
+
+        try:
+            uri = SMARTRENT_WEBSOCKET_URI.format(self.get_current_token())
+
+            await sender(uri, payload)
+
+        except websockets.exceptions.InvalidStatusCode as exc:
+            _LOGGER.debug(
+                'Possible issue during send_payload: "%s" '
+                "Refreshing token and retrying",
+                exc,
+            )
+
+            # update token once
+            await self.async_refresh_token()
+
+            uri = SMARTRENT_WEBSOCKET_URI.format(self.get_current_token())
+
+            await sender(uri, payload)

--- a/smartrent/utils.py
+++ b/smartrent/utils.py
@@ -305,7 +305,11 @@ class Client:
                         )
 
                         if event_type:
-                            event = f"{event_type:<15} -> {event_name:<15} -> {event_last_read_state:<20}"
+                            event = (
+                                f"{event_type:<15} -> "
+                                f"{event_name:<15} -> "
+                                f"{event_last_read_state:<20}"
+                            )
                             _LOGGER.info(event)
 
                             for device in self._subscribed_devices:


### PR DESCRIPTION
Before this change each `device` object would handle its own websocket connection to smartrent. So if an apartment had four devices, that would be four separate websocket connections to smartrents api. Instead we can just create one websocket connection that all devices share where they subscribe to updates from the websocket.

It also made the device class kind of bloated with code that doesn't really represent a state of a device.

The change will not impact functionality.