### PR TITLE
Upgraded Websockets to mitigate issue in Home Assistant 2024.12.0b2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,7 +111,6 @@ env/
 venv/
 ENV/
 env.bak/
-venv.bak/
 
 # Spyder project settings
 .spyderproject

--- a/.gitignore
+++ b/.gitignore
@@ -25,11 +25,7 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-test.py
-.idx
-.vscode
-.venv
-.github
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.
@@ -140,3 +136,8 @@ dmypy.json
 
 # Cython debug symbols
 cython_debug/
+
+# IDEs
+.idx
+.vscode
+.github

--- a/.gitignore
+++ b/.gitignore
@@ -25,7 +25,11 @@ share/python-wheels/
 .installed.cfg
 *.egg
 MANIFEST
-
+test.py
+.idx
+.vscode
+.venv
+.github
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "smartrent-py"
-version = "0.4.4"
+version = "0.4.5"
 description = "Unofficial Python API for SmartRent devices"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 aiohttp = "^3.8.4"
 python = ">=3.6.1,<4.0.0"
-websockets = "^11.0.1"
+websockets = "^13.1"
 
 [build-system]
 requires = ["setuptools >= 35.0.2", "wheel >= 0.29.0", "poetry>=0.12"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-websockets>=11.0.1
+websockets>=13.1
 aiohttp>=3.8.4


### PR DESCRIPTION
Home Assistant 2024.12.0b2 is having conflicts because it pushes the Websockets version beyond 12, so I've adjusted the package to use Websockets 13.1.  Not the newest, but it seems to be safe and stable.  Please double-check if I missed anything.  Feel free to adjust as needed.