### PR TITLE
Add Github action to tag commit based on pyproject.yml

### DIFF
--- a/.github/workflows/tag-version.yml
+++ b/.github/workflows/tag-version.yml
@@ -1,0 +1,42 @@
+name: Tag Version on Bump
+
+on:
+  push:
+    paths:
+      - pyproject.toml
+      - .github/workflows/tag-version.yml # allow version tagging to proceed if this file needs to be fixed
+    branches:
+      - main  
+jobs:
+  tag_version:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Important for tags!
+
+      - name: Extract version from pyproject.toml
+        id: get_version
+        run: |
+          VERSION=$(grep '^version' pyproject.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Check if tag exists
+        id: check_tag
+        run: |
+          TAG="v${{ steps.get_version.outputs.version }}"
+          if git rev-parse "$TAG" >/dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Tag commit if version bump and tag does not exist
+        if: steps.check_tag.outputs.exists == 'false'
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "v${{ steps.get_version.outputs.version }}"
+          git push origin "v${{ steps.get_version.outputs.version }}"


### PR DESCRIPTION
Hi Zachery! We chatted on linkedin a couple months back, when I reached out to thank you for this integration.

I understand you are no longer able to take as active a hand in maintaining this project, due to not being a user of it yourself anymore, and thought I'd offer to take more of a hand in maintaining the repo, as I have come to depend on it quite often. One thing I think I can do to help, right now, is make it easier to do a new release. 

I noticed a tag wasn't created with the last commit, despite the version getting bumped in the pyproject.toml file.

This PR adds a Github action (.github/workflows/tag-version.yml) to automatically tag a release with the corresponding version number from the pyproject.toml file, which should make it easier to update this home assistant component as well, as you won't have to manually tag anymore, which I think you may have been. 

I tested the action in my own repo, and reverted my commit to keep my fork at parity with your main branch. 
<img width="934" height="424" alt="Screenshot 2025-09-13 12 14 44 PM" src="https://github.com/user-attachments/assets/a8ad4b78-c7fd-4931-87e9-d94ecf49a788" />
<img width="934" height="363" alt="Screenshot 2025-09-13 12 12 54 PM" src="https://github.com/user-attachments/assets/2647aea7-8638-4750-a62a-3b6c6af29ba9" />

Here are the logs from the run:
```
2025-09-13T19:06:00.9979226Z Current runner version: '2.328.0'
2025-09-13T19:06:01.0010440Z ##[group]Runner Image Provisioner
2025-09-13T19:06:01.0011743Z Hosted Compute Agent
2025-09-13T19:06:01.0012590Z Version: 20250829.383
2025-09-13T19:06:01.0013468Z Commit: 27cb235aab5b0e52e153a26cd86b4742e89dac5d
2025-09-13T19:06:01.0014963Z Build Date: 2025-08-29T13:48:48Z
2025-09-13T19:06:01.0015868Z ##[endgroup]
2025-09-13T19:06:01.0016654Z ##[group]Operating System
2025-09-13T19:06:01.0017633Z Ubuntu
2025-09-13T19:06:01.0018368Z 24.04.3
2025-09-13T19:06:01.0019067Z LTS
2025-09-13T19:06:01.0019798Z ##[endgroup]
2025-09-13T19:06:01.0020645Z ##[group]Runner Image
2025-09-13T19:06:01.0021486Z Image: ubuntu-24.04
2025-09-13T19:06:01.0022366Z Version: 20250907.24.1
2025-09-13T19:06:01.0024006Z Included Software: https://github.com/actions/runner-images/blob/ubuntu24/20250907.24/images/ubuntu/Ubuntu2404-Readme.md
2025-09-13T19:06:01.0026958Z Image Release: https://github.com/actions/runner-images/releases/tag/ubuntu24%2F20250907.24
2025-09-13T19:06:01.0028642Z ##[endgroup]
2025-09-13T19:06:01.0032723Z ##[group]GITHUB_TOKEN Permissions
2025-09-13T19:06:01.0035514Z Actions: write
2025-09-13T19:06:01.0036325Z Attestations: write
2025-09-13T19:06:01.0037228Z Checks: write
2025-09-13T19:06:01.0038080Z Contents: write
2025-09-13T19:06:01.0038913Z Deployments: write
2025-09-13T19:06:01.0039691Z Discussions: write
2025-09-13T19:06:01.0040538Z Issues: write
2025-09-13T19:06:01.0041273Z Metadata: read
2025-09-13T19:06:01.0042130Z Models: read
2025-09-13T19:06:01.0042895Z Packages: write
2025-09-13T19:06:01.0043820Z Pages: write
2025-09-13T19:06:01.0044799Z PullRequests: write
2025-09-13T19:06:01.0045644Z RepositoryProjects: write
2025-09-13T19:06:01.0046475Z SecurityEvents: write
2025-09-13T19:06:01.0047599Z Statuses: write
2025-09-13T19:06:01.0048454Z ##[endgroup]
2025-09-13T19:06:01.0052005Z Secret source: Actions
2025-09-13T19:06:01.0053522Z Prepare workflow directory
2025-09-13T19:06:01.0502537Z Prepare all required actions
2025-09-13T19:06:01.0557790Z Getting action download info
2025-09-13T19:06:01.2989150Z Download action repository 'actions/checkout@v4' (SHA:08eba0b27e820071cde6df949e0beb9ba4906955)
2025-09-13T19:06:01.5529053Z Complete job name: tag_version
2025-09-13T19:06:01.6576476Z ##[group]Run actions/checkout@v4
2025-09-13T19:06:01.6577622Z with:
2025-09-13T19:06:01.6578202Z   fetch-depth: 0
2025-09-13T19:06:01.6578885Z   repository: jamesbiederbeck/smartrent-py
2025-09-13T19:06:01.6579963Z   token: ***
2025-09-13T19:06:01.6580545Z   ssh-strict: true
2025-09-13T19:06:01.6581151Z   ssh-user: git
2025-09-13T19:06:01.6581777Z   persist-credentials: true
2025-09-13T19:06:01.6582468Z   clean: true
2025-09-13T19:06:01.6583089Z   sparse-checkout-cone-mode: true
2025-09-13T19:06:01.6583845Z   fetch-tags: false
2025-09-13T19:06:01.6584656Z   show-progress: true
2025-09-13T19:06:01.6585297Z   lfs: false
2025-09-13T19:06:01.6585877Z   submodules: false
2025-09-13T19:06:01.6586531Z   set-safe-directory: true
2025-09-13T19:06:01.6587527Z ##[endgroup]
2025-09-13T19:06:01.7669984Z Syncing repository: jamesbiederbeck/smartrent-py
2025-09-13T19:06:01.7671674Z ##[group]Getting Git version info
2025-09-13T19:06:01.7672455Z Working directory is '/home/runner/work/smartrent-py/smartrent-py'
2025-09-13T19:06:01.7673416Z [command]/usr/bin/git version
2025-09-13T19:06:01.9032392Z git version 2.51.0
2025-09-13T19:06:01.9059755Z ##[endgroup]
2025-09-13T19:06:01.9074934Z Temporarily overriding HOME='/home/runner/work/_temp/c1d6a750-9a73-44af-b9bf-d661a5edc2a4' before making global git config changes
2025-09-13T19:06:01.9077400Z Adding repository directory to the temporary git global config as a safe directory
2025-09-13T19:06:01.9089949Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/smartrent-py/smartrent-py
2025-09-13T19:06:01.9128183Z Deleting the contents of '/home/runner/work/smartrent-py/smartrent-py'
2025-09-13T19:06:01.9132341Z ##[group]Initializing the repository
2025-09-13T19:06:01.9136777Z [command]/usr/bin/git init /home/runner/work/smartrent-py/smartrent-py
2025-09-13T19:06:01.9232194Z hint: Using 'master' as the name for the initial branch. This default branch name
2025-09-13T19:06:01.9233985Z hint: is subject to change. To configure the initial branch name to use in all
2025-09-13T19:06:01.9235691Z hint: of your new repositories, which will suppress this warning, call:
2025-09-13T19:06:01.9236780Z hint:
2025-09-13T19:06:01.9237535Z hint: 	git config --global init.defaultBranch <name>
2025-09-13T19:06:01.9238333Z hint:
2025-09-13T19:06:01.9238912Z hint: Names commonly chosen instead of 'master' are 'main', 'trunk' and
2025-09-13T19:06:01.9239818Z hint: 'development'. The just-created branch can be renamed via this command:
2025-09-13T19:06:01.9240492Z hint:
2025-09-13T19:06:01.9240862Z hint: 	git branch -m <name>
2025-09-13T19:06:01.9241538Z hint:
2025-09-13T19:06:01.9242331Z hint: Disable this message with "git config set advice.defaultBranchName false"
2025-09-13T19:06:01.9243371Z Initialized empty Git repository in /home/runner/work/smartrent-py/smartrent-py/.git/
2025-09-13T19:06:01.9247321Z [command]/usr/bin/git remote add origin https://github.com/jamesbiederbeck/smartrent-py
2025-09-13T19:06:01.9284074Z ##[endgroup]
2025-09-13T19:06:01.9285014Z ##[group]Disabling automatic garbage collection
2025-09-13T19:06:01.9287854Z [command]/usr/bin/git config --local gc.auto 0
2025-09-13T19:06:01.9314950Z ##[endgroup]
2025-09-13T19:06:01.9315680Z ##[group]Setting up auth
2025-09-13T19:06:01.9321558Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2025-09-13T19:06:01.9349561Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2025-09-13T19:06:01.9673234Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2025-09-13T19:06:01.9706369Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2025-09-13T19:06:01.9937353Z [command]/usr/bin/git config --local http.https://github.com/.extraheader AUTHORIZATION: basic ***
2025-09-13T19:06:01.9976807Z ##[endgroup]
2025-09-13T19:06:01.9977995Z ##[group]Fetching the repository
2025-09-13T19:06:02.0000211Z [command]/usr/bin/git -c protocol.version=2 fetch --prune --no-recurse-submodules origin +refs/heads/*:refs/remotes/origin/* +refs/tags/*:refs/tags/*
2025-09-13T19:06:02.2195970Z From https://github.com/jamesbiederbeck/smartrent-py
2025-09-13T19:06:02.2196851Z  * [new branch]      main       -> origin/main
2025-09-13T19:06:02.2233622Z [command]/usr/bin/git branch --list --remote origin/main
2025-09-13T19:06:02.2255107Z   origin/main
2025-09-13T19:06:02.2263900Z [command]/usr/bin/git rev-parse refs/remotes/origin/main
2025-09-13T19:06:02.2283948Z b401c43c31e9151db5602c2bbd197713f27dfb94
2025-09-13T19:06:02.2289744Z ##[endgroup]
2025-09-13T19:06:02.2290877Z ##[group]Determining the checkout info
2025-09-13T19:06:02.2292129Z ##[endgroup]
2025-09-13T19:06:02.2294410Z [command]/usr/bin/git sparse-checkout disable
2025-09-13T19:06:02.2334051Z [command]/usr/bin/git config --local --unset-all extensions.worktreeConfig
2025-09-13T19:06:02.2358599Z ##[group]Checking out the ref
2025-09-13T19:06:02.2361932Z [command]/usr/bin/git checkout --progress --force -B main refs/remotes/origin/main
2025-09-13T19:06:02.2413847Z Switched to a new branch 'main'
2025-09-13T19:06:02.2417123Z branch 'main' set up to track 'origin/main'.
2025-09-13T19:06:02.2423282Z ##[endgroup]
2025-09-13T19:06:02.2456942Z [command]/usr/bin/git log -1 --format=%H
2025-09-13T19:06:02.2478312Z b401c43c31e9151db5602c2bbd197713f27dfb94
2025-09-13T19:06:02.2653784Z ##[group]Run VERSION=$(grep '^version' pyproject.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')
2025-09-13T19:06:02.2655455Z [36;1mVERSION=$(grep '^version' pyproject.toml | head -n 1 | sed 's/version = "\(.*\)"/\1/')[0m
2025-09-13T19:06:02.2656610Z [36;1mecho "VERSION=$VERSION" >> $GITHUB_ENV[0m
2025-09-13T19:06:02.2657246Z [36;1mecho "version=$VERSION" >> $GITHUB_OUTPUT[0m
2025-09-13T19:06:02.2709535Z shell: /usr/bin/bash -e {0}
2025-09-13T19:06:02.2710051Z ##[endgroup]
2025-09-13T19:06:02.2890837Z ##[group]Run TAG="v0.5.2"
2025-09-13T19:06:02.2891367Z [36;1mTAG="v0.5.2"[0m
2025-09-13T19:06:02.2891864Z [36;1mif git rev-parse "$TAG" >/dev/null 2>&1; then[0m
2025-09-13T19:06:02.2892533Z [36;1m  echo "exists=true" >> $GITHUB_OUTPUT[0m
2025-09-13T19:06:02.2893139Z [36;1melse[0m
2025-09-13T19:06:02.2893608Z [36;1m  echo "exists=false" >> $GITHUB_OUTPUT[0m
2025-09-13T19:06:02.2894206Z [36;1mfi[0m
2025-09-13T19:06:02.2922726Z shell: /usr/bin/bash -e {0}
2025-09-13T19:06:02.2923202Z env:
2025-09-13T19:06:02.2923550Z   VERSION: 0.5.2
2025-09-13T19:06:02.2923920Z ##[endgroup]
2025-09-13T19:06:02.3043265Z ##[group]Run git config --global user.name "github-actions[bot]"
2025-09-13T19:06:02.3044166Z [36;1mgit config --global user.name "github-actions[bot]"[0m
2025-09-13T19:06:02.3045482Z [36;1mgit config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"[0m
2025-09-13T19:06:02.3046405Z [36;1mgit tag "v0.5.2"[0m
2025-09-13T19:06:02.3046882Z [36;1mgit push origin "v0.5.2"[0m
2025-09-13T19:06:02.3074854Z shell: /usr/bin/bash -e {0}
2025-09-13T19:06:02.3075433Z env:
2025-09-13T19:06:02.3075794Z   VERSION: 0.5.2
2025-09-13T19:06:02.3076196Z ##[endgroup]
2025-09-13T19:06:02.8477886Z To https://github.com/jamesbiederbeck/smartrent-py
2025-09-13T19:06:02.8479980Z  * [new tag]         v0.5.2 -> v0.5.2
2025-09-13T19:06:02.8694146Z Post job cleanup.
2025-09-13T19:06:02.9616036Z [command]/usr/bin/git version
2025-09-13T19:06:02.9650684Z git version 2.51.0
2025-09-13T19:06:02.9688740Z Copying '/home/runner/.gitconfig' to '/home/runner/work/_temp/2d155b0d-3537-4d75-9fce-832d4bbb620e/.gitconfig'
2025-09-13T19:06:02.9698778Z Temporarily overriding HOME='/home/runner/work/_temp/2d155b0d-3537-4d75-9fce-832d4bbb620e' before making global git config changes
2025-09-13T19:06:02.9702021Z Adding repository directory to the temporary git global config as a safe directory
2025-09-13T19:06:02.9710254Z [command]/usr/bin/git config --global --add safe.directory /home/runner/work/smartrent-py/smartrent-py
2025-09-13T19:06:02.9743171Z [command]/usr/bin/git config --local --name-only --get-regexp core\.sshCommand
2025-09-13T19:06:02.9775507Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'core\.sshCommand' && git config --local --unset-all 'core.sshCommand' || :"
2025-09-13T19:06:02.9997135Z [command]/usr/bin/git config --local --name-only --get-regexp http\.https\:\/\/github\.com\/\.extraheader
2025-09-13T19:06:03.0016827Z http.https://github.com/.extraheader
2025-09-13T19:06:03.0030706Z [command]/usr/bin/git config --local --unset-all http.https://github.com/.extraheader
2025-09-13T19:06:03.0061900Z [command]/usr/bin/git submodule foreach --recursive sh -c "git config --local --name-only --get-regexp 'http\.https\:\/\/github\.com\/\.extraheader' && git config --local --unset-all 'http.https://github.com/.extraheader' || :"
2025-09-13T19:06:03.0398779Z Cleaning up orphan processes
```

